### PR TITLE
Fix do-end block detection regexp

### DIFF
--- a/rhtml-erb.el
+++ b/rhtml-erb.el
@@ -123,7 +123,7 @@ line, respectively."
          (if (rhtml-scan-for-erb-tags '(erb-middle)) (- sgml-basic-offset) 0)))))
 
 (defconst rhtml-erb-block-open-re
-  (concat "[A-Za-z_)][ ]+do[ ]+\\(?:|[A-Za-z_, ]*|\\)?[ ]*" rhtml-erb-tag-close-re))
+  (concat "[]A-Za-z_)}][ ]+do[ ]+\\(?:|[A-Za-z_, ]*|\\)?[ ]*" rhtml-erb-tag-close-re))
 
 (defconst rhtml-erb-brace-block-open-re
   (concat "[ ]+{[ ]+\\(?:|[A-Za-z_, ]*|\\)?[ ]*" rhtml-erb-tag-close-re)


### PR DESCRIPTION
e.g
  form_for [:admin, @message] do |f|
  form_for @message, {:url => msg} do |f|
