### PR TITLE
Add autoloads for rhtml-mode and auto-mode-alist

### DIFF
--- a/rhtml-mode.el
+++ b/rhtml-mode.el
@@ -43,6 +43,7 @@
 ;; don't require if you don't want it...
 (require 'rhtml-sgml-hacks) ;; indent erb with sgml
 
+;;;###autoload
 (define-derived-mode rhtml-mode
   html-mode "RHTML"
   "Embedded Ruby Mode (RHTML)"
@@ -51,6 +52,7 @@
   ;; disable if you don't want it...
   (rhtml-activate-fontification))
 
+;;;###autoload
 (add-to-list 'auto-mode-alist '("\\.html\\.erb$" . rhtml-mode))
 
 (define-key ruby-mode-map


### PR DESCRIPTION
This allows RHTML to work for package management users without needing
to add (require 'rhtml-mode) to their init.el.

Signed-off-by: Erik Charlebois erikcharlebois@gmail.com

(This also makes it work nicely with package management for MELPA if you'd like to put it up there).
